### PR TITLE
Add full page screenshot capability

### DIFF
--- a/src/imageCompare.js
+++ b/src/imageCompare.js
@@ -46,11 +46,12 @@ function clearErrors() {
 
 /**
  * Take screenshot using W3C mode only
- * @param {string} resultPathPositive - Path to save the screenshot
- * @param {string} elementSelector - CSS selector for element screenshot (optional)
+ * @param {string}  resultPathPositive - Path to save the screenshot
+ * @param {string}  elementSelector - CSS selector for element screenshot (optional)
+ * @param {boolean} fullPage - whether to take a screenshot of the full page (optional)
  * @returns {Promise<void>}
  */
-async function takeScreenshotImage(resultPathPositive, elementSelector = null) {
+async function takeScreenshotImage(resultPathPositive, elementSelector = null, fullPage = false) {
   try {
     if (elementSelector) {
       // Element screenshot using W3C mode
@@ -60,7 +61,7 @@ async function takeScreenshotImage(resultPathPositive, elementSelector = null) {
     } else {
       // Page screenshot using W3C mode
       // Use direct Promise-based approach for WebdriverIO v9+
-      await browser.saveScreenshot(resultPathPositive);
+      await browser.saveScreenshot(resultPathPositive, { fullPage : fullPage });
     }
   } catch (error) {
     console.error(`Screenshot failed: ${error.message}`);
@@ -262,7 +263,7 @@ class ImageAssertion {
 }
 
 // takePageImage function to take a screenshot of the page
-async function takePageImage(filename, elementSnapshot = null, elementsToHide = null) {
+async function takePageImage(filename, elementSnapshot = null, elementsToHide = null, fullPage = false) {
   const envName = env.envName.toLowerCase();
   const resultDir = `./artifacts/visual-regression/original/${browserName}/${envName}/`;
   const resultDirPositive = `${resultDir}positive/`;
@@ -276,7 +277,7 @@ async function takePageImage(filename, elementSnapshot = null, elementsToHide = 
 
   try {
     // Use the new mode-aware screenshot function
-    await takeScreenshotImage(resultPathPositive, elementSnapshot);
+    await takeScreenshotImage(resultPathPositive, elementSnapshot, fullPage);
   } catch (error) {
     const errorMessage = error && typeof error === 'object' && error.message ? error.message :
       error && typeof error === 'string' ? error :

--- a/utils/common.js
+++ b/utils/common.js
@@ -25,7 +25,7 @@ async function compareImage(fileName){
  * @param waitBeforeCapture
  * @returns {Promise<void>}
  */
-async function takeImage(fileName, elementSnapshot, elementsToHide = '', shouldCompare = true, expectedTolerance = 0.2, waitBeforeCapture = 100) {
+async function takeImage(fileName, elementSnapshot, elementsToHide = '', fullPage = false, shouldCompare = true, expectedTolerance = 0.2, waitBeforeCapture = 100) {
     // Automatically start a new test run if there are no existing errors
     // This means we're starting fresh and should clear the state
     if (shouldStartNewTestRun()) {
@@ -35,7 +35,7 @@ async function takeImage(fileName, elementSnapshot, elementsToHide = '', shouldC
     if (waitBeforeCapture > 0) {
         await browser.pause(waitBeforeCapture);
     }
-    await takePageImage(fileName, elementSnapshot, elementsToHide);
+    await takePageImage(fileName, elementSnapshot, elementsToHide, fullPage);
 
     // Perform comparison if requested
     if (shouldCompare) {


### PR DESCRIPTION
This PR adds full page screenshot capability to `takeImage`.

Tested on example-test-suite main branch, with only two changes:
- package.json : link to this branch
- page-objects/visualValidation.js : change ln34 to ```await takeImage(`${image}-results_1-2.png`, null, sharedObjects.searchData.elem.leftBadge, true);```

Running the test created full page screenshots, titled ___-results_1-2.png, in the artifacts folder.